### PR TITLE
fix random_split for 1.5.0

### DIFF
--- a/model/data_loader.py
+++ b/model/data_loader.py
@@ -87,6 +87,9 @@ def fetch_dataloader(data_dir, batch_size, validation_split):
     split = int(np.floor(validation_split * dataset_size))
     print(split)
     random_seed = 42
+    # fix the random generator for train and test
+    # taken from https://pytorch.org/docs/1.5.0/notes/randomness.html
+    torch.manual_seed(random_seed)
     train_subset, val_subset = torch.utils.data.random_split(dataset, [dataset_size - split, split])#,
 #                                                             generator=torch.Generator().manual_seed(random_seed))
     print(len(train_subset), len(val_subset))


### PR DESCRIPTION
to fix the random_split between train and test for pytorch 1.5.0, such that different trainings can use the same train and test events.
did not run the full test. however testing the `random_split` function and it seems to work as expected.